### PR TITLE
Remove Renovate dependency update bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
## Summary
- Remove Renovate config (and Dependabot config if present)
- Related bot PRs are being closed separately

No longer using Renovate or Dependabot for dependency updates on this repo.